### PR TITLE
Update dependencies, use trieval from hex

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.1.2
-elixir 1.17.3-otp-27
+erlang 27.2.1
+elixir 1.18.2-otp-27

--- a/mix.exs
+++ b/mix.exs
@@ -27,10 +27,8 @@ defmodule Simplesearch.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
       {:stemmer, git: "https://github.com/fredwu/stemmer.git", tag: "v1.2.0"},
-      {:trieval, git: "https://github.com/pathpub/trieval.git", tag: "v1.0.0"},
+      {:trieval, "~> 1.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
   "stemmer": {:git, "https://github.com/fredwu/stemmer.git", "4a96c356e0d9bfb2a2b03ebd4eac03371bf9067a", [tag: "v1.2.0"]},
-  "trieval": {:git, "https://github.com/pathpub/trieval.git", "3e7491a8fdd2b76f9ec8f07a0a478905c884cc16", [tag: "v1.0.0"]},
+  "trieval": {:hex, :trieval, "1.1.0", "3581e4ef4016e8375dc2c7b54499c5affebcb29957d1a03da3fd50f0f0ab6311", [:mix], [], "hexpm", "f698c38273ce5663702c7a58e60748bd529997ee702eef0682f7f6dbdc736929"},
 }


### PR DESCRIPTION
[ticket](https://github.com/pathpub/simplesearch/issues/1)

I updated the most recent release of trieval to use the latest erlang and elixir versions. I may have done that in haste..
Let me know if updating to these newer versions is going to cause you issues as there wasn't any actual need for me to update them in trieval.